### PR TITLE
Make backuptool permissive only in non user builds

### DIFF
--- a/common/private/backuptool.te
+++ b/common/private/backuptool.te
@@ -1,9 +1,11 @@
 type backuptool, domain, coredomain;
 
-permissive backuptool;
-
 neverallow {
     domain
     -recovery
     -update_engine
 } backuptool:process transition;
+
+userdebug_or_eng(`
+    permissive backuptool;
+')


### PR DESCRIPTION
Change-Id: Ic95e5a328e429f59f5ca2ca2d6767b9258fce28a

This pull request is relating to following links:

https://github.com/SigmaDroid-Project/manifest/blob/589db52a61fd436006350cf393927f9a1178061f/snippets/crdroid.xml#L79

https://github.com/crdroidandroid/android_system_sepolicy/blob/1ff8b0195253f1dcecd89d787eb38d9ec4720aea/build/soong/policy.go#L533-L535